### PR TITLE
Revise IDSA Rulebook description and scope

### DIFF
--- a/Working-Groups/WG-Rulebook.md
+++ b/Working-Groups/WG-Rulebook.md
@@ -1,7 +1,18 @@
 ## Working Group Rulebook 
 
 ### Description:
-***The IDSA Rulebook Working Group*** is responsible for the development and continuous maintenance of the IDSA Rulebook, which serves as the authoritative framework governing secure, fair, and trustworthy cross-organizational data sharing. The Rulebook provides comprehensive provisions applicable to various forms of data exchange, including data sharing ecosystems, peer-to-peer data sharing, data marketplaces, and data-driven platforms.
+***The IDSA Rulebook Working Group*** is responsible for the development and continuous maintenance of the IDSA Rulebook, which serves as the authoritative framework governing trusted cross-organizational data sharing. 
+
+The IDSA Rulebook supports the creation, operation, and growth of data spaces by distinguishing mandatory requirements from optional, value-adding practices. Its scope spans technical, commercial, and legal dimensions:
+
+- Common technical guidance, including functional requirements and specifications.
+- Recommendations for applying IDSA technical artefacts and for alignment with partner frameworks.
+- Operational guidance for collaboration, roles, and processes that enable data space ecosystems.
+- Perspectives on implementing and complying with international legal and regulatory obligations to facilitate trusted, cross-border data sharing.
+
+The IDSA Rulebook is addressing the broad community of actors who design, build, operate, regulate, or participate in data spaces. That includes private enterprises, public sector organizations, research institutions, standards bodies, and individuals who are responsible for data governance, stewardship, compliance, or innovation. As data sharing assumes an ever more fundamental role in economic activity and public policy, a clear understanding of the principles, requirements and governance models set out in the IDSA Rulebook is essential.
+
+The IDSA Rulebook offers practical guidance for those working with diverse forms of data sharing — from decentralized peer-to-peer sharing and federated ecosystems to data marketplaces and platform-based services. It is especially useful for readers who seek to promote trustworthy data sharing; to manage business risk and contractual governance; and to implement technical architectures that preserve participant autonomy and agency.
 
 ### Chair:
 - Peter Koen, Microsoft
@@ -15,10 +26,7 @@
 
 ### Meetings:
 - Quarterly meetings open for all IDSA members.
-- Task force meetings for subgroups of the WG Rulebook.
+- Task force meetings for subgroups of the WG Rulebook at varying, agile schedules.
 
 ### Artifact(s):
 :green_book: [IDSA Rulebook](https://docs.internationaldataspaces.org/idsa-knowledge-base/v/idsa-rulebook/front-matter/readme)
-
-
-### Relevant Webinars & Events:


### PR DESCRIPTION
Expanded the description of the IDSA Rulebook Working Group to clarify its purpose and scope, including guidance on technical, commercial, and legal aspects of data sharing.